### PR TITLE
Make download link into button + open in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <br>
       <button type="submit">Play</button>
       <button onclick="javascript:stopPlayback()" type="button">Stop</button>
-      <a id="tts-download" href="/tts?text=aeiou">Download</a>
+      <a id="tts-download" href="/tts?text=aeiou" target="_blank"><button type="button">Download</button></a>
     </form>
     <audio id="result-audio">
       Your browser does not support the HTML5 audio element.
@@ -58,6 +58,7 @@
         let downloadLink = document.getElementById('tts-download');
         downloadLink.href = `/tts?text=${encodeURIComponent(text)}`;
       };
+
       document.getElementById('input-text').onkeydown = ev => {
         if (ev.key === 'Enter' && ev.ctrlKey && !playing) tts();
       };


### PR DESCRIPTION
The download link sitting next to two buttons on the page looks kind of out of place. This patch allows it to retain the functionality of a link, but looks more consistent with the other buttons on the page. Also, since it no longer looks like a link, the user might not know to right click->open in new tab or middle click in order to not replace the current window and potentially lose work, so the download will open in a new tab by default. Note: the benefits of being able to do link-related stuff like copy into another downloading tool still apply.

(This is kind of a personal stylistic preference change, feel free to close if you don't like it.)