### PR TITLE
Make play/stop buttons toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
       <br>
       <textarea maxlength="1024" id="input-text" cols="60" rows="10">aeiou</textarea>
       <br>
-      <button type="submit">Play</button>
-      <button onclick="javascript:stopPlayback()" type="button">Stop</button>
+      <button id="play" type="submit">Play</button>
+      <button id="stop" type="button" hidden>Stop</button>
       <a id="tts-download" href="/tts?text=aeiou">Download</a>
     </form>
     <p><strong id="error-output" style="color: red"></strong></p>
@@ -39,10 +39,25 @@
       });
       audio.addEventListener('playing', () => {
         playing = true;
+        updateButtons();
       });
       audio.addEventListener('ended', () => {
         playing = false;
+        updateButtons();
       });
+
+      function updateButtons() {
+        let playBtn = document.getElementById('play');
+        let stopBtn = document.getElementById('stop');
+
+        if (playing) {
+          playBtn.hidden = true;
+          stopBtn.hidden = false;
+        } else {
+          playBtn.hidden = false;
+          stopBtn.hidden = true;
+        }
+      }
 
       function tts() {
         let text = document.getElementById('input-text').value;
@@ -77,6 +92,7 @@
       document.getElementById('input-text').onkeydown = ev => {
         if (ev.key === 'Enter' && ev.ctrlKey && !playing) tts();
       };
+      document.getElementById('stop').onclick = stopPlayback;
     </script>
   </body>
 </html>


### PR DESCRIPTION
Currently, the play/stop buttons are both present and clickable whether audio is playing or not. It's not possible to visually tell whether playback is occuring, which is frustrating when your audio contains long periods of silence.

This change makes it so only one button is visible at a time. When playback starts, the play button gets replaced by the stop button, so the user doesn't need to move their mouse to stop playback. This also provides a clear visual indication for whether audio is playing.